### PR TITLE
fix: When feature evaluation fails, the details object returned now has it…

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -139,7 +139,7 @@ public class OpenFeatureClient implements Client {
         } catch (Exception e) {
             log.error("Unable to correctly evaluate flag with key '{}'", key, e);
             if (details == null) {
-                details = FlagEvaluationDetails.<T>builder().build();
+                details = FlagEvaluationDetails.<T>builder().flagKey(key).build();
             }
             if (e instanceof OpenFeatureError) {
                 details.setErrorCode(((OpenFeatureError) e).getErrorCode());

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -67,4 +67,18 @@ class OpenFeatureClientTest implements HookFixtures {
 
         assertThat(result.getValue()).isTrue();
     }
+
+    @Test
+    void errorDetailsWhenDefaultValueIsNullHasNonNullFlagKey() {
+        OpenFeatureAPI api = mock(OpenFeatureAPI.class);
+        when(api.getProvider(any())).thenReturn(new DoSomethingProvider());
+        when(api.getHooks()).thenReturn(Arrays.asList(mockBooleanHook(), mockStringHook()));
+
+        //noinspection deprecation
+        OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
+
+        FlagEvaluationDetails<Boolean> actual = client.getBooleanDetails("feature key", null);
+
+        assertThat(actual.getFlagKey()).isNotNull();
+    }
 }


### PR DESCRIPTION
When feature flag evaluation failed due to a null default value, the returned details object had a null flagKey value instead of the provided key value.